### PR TITLE
Updating helix-query.yaml to include manifests index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -3,7 +3,7 @@ indices:
   channels:
     include:
       - '/screens/menus/**'
-    target: '/screens/channels'
+    target: '/screens/menus/channels'
     properties:
       title:
         select: head > meta[property="og:title"]
@@ -32,3 +32,32 @@ indices:
         select: head > meta[name="editurl"]
         value: |
           attribute(el, 'content')
+  channel-manifest:
+    include:
+      - '/screens/menus/**'
+    target: '/screens/menus/manifests'
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: |
+          attribute(el, 'content')
+      lastModified:
+        select: none
+        value: |
+          parseTimestamp(headers['last-modified'], 'ddd, DD MMM YYYY hh:mm:ss GMT')
+      scripts:
+        select: head > script[src]
+        values: |
+          attribute(el, 'src')
+      styles:
+        select: head > link[rel="stylesheet"]
+        values: |
+          attribute(el, 'href')
+      assets:
+        select: head > link[rel*="preload"]
+        values: |
+          attribute(el, 'href')
+      inline-images:
+        select: body img
+        values: |
+          attribute(el, 'src')   

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -3,7 +3,7 @@ indices:
   channels:
     include:
       - '/screens/menus/**'
-    target: '/screens/menus/channels'
+    target: '/screens/internal/channels'
     properties:
       title:
         select: head > meta[property="og:title"]
@@ -35,7 +35,7 @@ indices:
   channel-manifest:
     include:
       - '/screens/menus/**'
-    target: '/screens/menus/manifests'
+    target: '/screens/internal/manifests'
     properties:
       title:
         select: head > meta[property="og:title"]


### PR DESCRIPTION
Fix https://github.com/hlxsites/caesars-screens/issues/2
Updating the channels index output path and including manifests index. 
Test URLs:
- Before: https://main--<repo>--<owner>.hlx.page/
- After: https://<branch>--<repo>--<owner>.hlx.page/
